### PR TITLE
Bump blueimp-load-image to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.13",
     "@fortawesome/free-regular-svg-icons": "^5.7.0",
     "@fortawesome/react-fontawesome": "^0.1.4",
-    "blueimp-load-image": "^2.23.0",
+    "blueimp-load-image": "^5.13.0",
     "react-dropzone": "5.1.1",
     "react-file-icon": "^0.2.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,10 +2774,10 @@ bluebird@^3.5.1, bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-blueimp-load-image@^2.23.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/blueimp-load-image/-/blueimp-load-image-2.24.0.tgz#ced5b78fc9b32b4743fc4f780d3305d56391f04f"
-  integrity sha512-fR/CNGEOqbcgbQC7+6hJKcxjD5updapWECbptrHrYpkacP1eXCOoA+92D0v49Sc+gwtxTDzu8nxNmYYd7AXzUg==
+blueimp-load-image@^5.13.0:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/blueimp-load-image/-/blueimp-load-image-5.13.0.tgz#685d302a5adaf99d980fadf3d94f70a8e6ab7d30"
+  integrity sha512-CMmLihVqW0AtRGObKIRxYaVUj+2hw2MkeNHoD2JuobpKZFnCCUVCBIeyYkh8xiq3DHIfHfvsp9l0VpM30k3EXQ==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"


### PR DESCRIPTION
We have an issue (https://github.com/GetStream/stream-chat-react/issues/196) currently in `stream-chat-react` related to server-side rendering and the `blueimp-load-image` library. The issue seems to have been fixed from blueimp's version `4.0.1` and on. But after testing the latest version it seems that there are no breaking changes for us, so going for that here.