### PR TITLE
check if img.toDataURL exists before processing

### DIFF
--- a/src/components/Thumbnail.js
+++ b/src/components/Thumbnail.js
@@ -67,6 +67,7 @@ export default class Thumbnail extends React.PureComponent<Props, State> {
     loadImage(
       image,
       (img) => {
+        if (!img.toDataURL) return;
         const base64data = img.toDataURL('image/jpeg');
         this.setState({
           imgSrc: base64data,


### PR DESCRIPTION
In `stream-chat-react` when you edit a message with an attached og scraped url which has `type: image` it's a url and doesnt have the toDataUrl function. 