### PR TITLE
Feature: add maxNumberOfFiles prop to ImageDropzone

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@fortawesome/free-regular-svg-icons": "^5.7.0",
     "@fortawesome/react-fontawesome": "^0.1.4",
     "blueimp-load-image": "^5.13.0",
-    "react-dropzone": "5.1.1",
+    "react-dropzone": "11.2.0",
     "react-file-icon": "^0.2.0"
   }
 }

--- a/src/components/FileUploadButton.js
+++ b/src/components/FileUploadButton.js
@@ -24,8 +24,12 @@ export default class FileUploadButton extends React.PureComponent<Props> {
   };
 
   render() {
+    let className = 'rfu-file-upload-button';
+    if (this.props.disabled) {
+      className = `${className} rfu-file-upload-button--disabled`;
+    }
     return (
-      <div className="rfu-file-upload-button">
+      <div className={className}>
         <label>
           <input
             type="file"

--- a/src/components/ImageDropzone.js
+++ b/src/components/ImageDropzone.js
@@ -1,7 +1,6 @@
 // @flow
 import * as React from 'react';
 import Dropzone from 'react-dropzone';
-import { dataTransferItemsToFiles } from '../utils';
 
 import type { FileLike } from '../types';
 
@@ -18,66 +17,71 @@ type Props = {|
    * One of type: `string, string[]`
    */
   accept?: string | string[],
+  maxNumberOfFiles?: number,
 |};
 
 export default class ImageDropzone extends React.PureComponent<Props> {
   static defaultProps = {
     multiple: true,
     disabled: false,
+    maxNumberOfFiles: 10,
   };
 
-  _handleFiles = async (accepted: File[], rejected: DataTransferItem[]) => {
+  _handleFiles = (accepted: File[]) => {
     const { handleFiles } = this.props;
     if (!handleFiles) {
       return;
     }
 
     if (accepted && accepted.length) {
-      // Normal case
       return handleFiles(accepted);
     }
-
-    const fileLikes = await dataTransferItemsToFiles(rejected);
-
-    // Website-to-website image drag+drop
-    if (fileLikes.length) {
-      return handleFiles(fileLikes);
-    }
   };
+
   render() {
-    const { handleFiles, children } = this.props;
+    const { handleFiles, maxNumberOfFiles, children } = this.props;
     return (
       <Dropzone
         onDrop={handleFiles && this._handleFiles}
+        maxFiles={maxNumberOfFiles}
         disableClick
         disablePreview
         //style={{position: 'absolute', height: '100%', width: '100%', zIndex: -1000000}}
-        className="rfu-dropzone"
-        style={{ position: 'relative' }}
         accept={this.props.accept}
         multiple={this.props.multiple}
         disabled={this.props.disabled}
-        acceptClassName="rfu-dropzone--accept"
-        rejectClassName="rfu-dropzone--reject"
       >
-        <div className="rfu-dropzone__notifier" style={{}}>
-          <div className="rfu-dropzone__inner">
-            <svg
-              width="41"
-              height="41"
-              viewBox="0 0 41 41"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M40.517 28.002V3.997c0-2.197-1.808-3.992-4.005-3.992H12.507a4.004 4.004 0 0 0-3.992 3.993v24.004a4.004 4.004 0 0 0 3.992 3.993h24.005c2.197 0 4.005-1.795 4.005-3.993zm-22.002-7.997l4.062 5.42 5.937-7.423 7.998 10H12.507l6.008-7.997zM.517 8.003V36c0 2.198 1.795 4.005 3.993 4.005h27.997V36H4.51V8.002H.517z"
-                fill="#000"
-                fillRule="nonzero"
-              />
-            </svg>
-            <p>Drag your files here to add to your post</p>
+        {({ getRootProps, isDragAccept, isDragReject }) => (
+          <div
+            {...getRootProps({
+              style: { position: 'relative' },
+              className: `
+            rfu-dropzone
+            ${isDragAccept ? 'rfu-dropzone--accept' : ''}
+            ${isDragReject ? 'rfu-dropzone--reject' : ''}
+          `,
+            })}
+          >
+            <div className="rfu-dropzone__notifier">
+              <div className="rfu-dropzone__inner">
+                <svg
+                  width="41"
+                  height="41"
+                  viewBox="0 0 41 41"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M40.517 28.002V3.997c0-2.197-1.808-3.992-4.005-3.992H12.507a4.004 4.004 0 0 0-3.992 3.993v24.004a4.004 4.004 0 0 0 3.992 3.993h24.005c2.197 0 4.005-1.795 4.005-3.993zm-22.002-7.997l4.062 5.42 5.937-7.423 7.998 10H12.507l6.008-7.997zM.517 8.003V36c0 2.198 1.795 4.005 3.993 4.005h27.997V36H4.51V8.002H.517z"
+                    fill="#000"
+                    fillRule="nonzero"
+                  />
+                </svg>
+                <p>Drag your files here to add to your post</p>
+              </div>
+            </div>
+            {children}
           </div>
-        </div>
-        {children}
+        )}
       </Dropzone>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1809,12 +1809,10 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-1.1.3.tgz#48230c79f93790ef2775fcec4f0db0f5db41ca52"
-  integrity sha512-iT40nudw8zmCweivz6j58g+RT33I4KbaIvRUhjNmDwO2WmsQUxFEZZYZ5w3vXe5x5MX9D7mfvA/XaLOZYFR9EQ==
-  dependencies:
-    core-js "^2.5.0"
+attr-accept@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 autoprefixer@^7.1.1:
   version "7.2.6"
@@ -5418,6 +5416,13 @@ file-loader@2.0.0:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
+
+file-selector@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.13.tgz#5efd977ca2bca1700992df1b10e254f4e73d2df4"
+  integrity sha512-T2efCBY6Ps+jLIWdNQsmzt/UnAjKOEAlsZVdnQztg/BtAZGNL4uX1Jet9cMM8gify/x4CSudreji2HssGBNVIQ==
+  dependencies:
+    tslib "^2.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -11037,13 +11042,14 @@ react-dom@^16.2.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-dropzone@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-5.1.1.tgz#b05613ea22f1ab71aa1f7cf5367df7b19468a2f3"
-  integrity sha512-C9kXI3D95rVXbLLg9DvzCnmjplKwpfj/2F/MwvGVM05kDwWMzKVKZnmgZHZUebmiVj4mFOmBs2ObLiKvAxunGw==
+react-dropzone@11.2.0:
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.2.0.tgz#4e54fa3479e6b6bb93f67914e4a27f1260807fdb"
+  integrity sha512-S/qaXQHCCg7MVlcrhqd05MLC6DupITLUB0CFn3iCLs6OTjzxdGDF1WTktTe5Jyq8jZdxYfMHNUZOHL0mg+K0Dw==
   dependencies:
-    attr-accept "^1.1.3"
-    prop-types "^15.6.2"
+    attr-accept "^2.0.0"
+    file-selector "^0.1.12"
+    prop-types "^15.7.2"
 
 react-error-overlay@^5.1.0, react-error-overlay@^5.1.4:
   version "5.1.6"
@@ -13201,6 +13207,11 @@ tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
This adds a `maxNumberOfFiles` prop to the `ImageDropzone` component. It prevents the user from dropping more files than the defined maximum into the dropzone.

Things that changed:
 - Upgraded `react-dropzone` to latest (5.1.1 -> 11.2.0) to use the newly added `maxFiles` prop
 - Updated syntax to accommodate the breaking changes introduced in `react-dropzone`
 - Removed "website to website image drag'n'drop" because it was buggy (and no longer supported by `react-dropzone`)
 - Adds `--disabled` modifier class to FileUploadButton wrapper div if it's disabled.

