### PR TITLE
Fix TSConfig to prevent jsx-runtime from being required

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowUnusedLabels": false,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "lib": ["esnext", "DOM"],
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
tsconfig compiler options: use 'react' instead of 'react-jsx' so 'jsx-runtime' isn't imported