### PR TITLE
Added resetOnChange property and custom handler

### DIFF
--- a/src/components/FileUploadButton.tsx
+++ b/src/components/FileUploadButton.tsx
@@ -1,12 +1,14 @@
-import React, { useRef } from 'react';
+import React from 'react';
 
 import { AttachmentIcon } from './AttachmentIcon';
+import { handleFileChange } from '../utils';
 
 export type FileUploadButtonProps = {
   handleFiles: (files: FileList | File[]) => void;
   multiple?: boolean;
   disabled?: boolean;
   accepts?: string | string[];
+  resetOnChange?: boolean;
 };
 
 export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
@@ -15,9 +17,8 @@ export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
   children = <AttachmentIcon />,
   handleFiles,
   accepts,
+  resetOnChange = false,
 }) => {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
   let className = 'rfu-file-upload-button';
   if (disabled) {
     className = `${className} rfu-file-upload-button--disabled`;
@@ -27,18 +28,8 @@ export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
       <label>
         <input
           type="file"
-          ref={inputRef}
           className="rfu-file-input"
-          onChange={(event) => {
-            const files = event.currentTarget.files;
-            if (files) {
-              handleFiles(files);
-            }
-            if (inputRef.current !== null) {
-              inputRef.current.value = '';
-              inputRef.current.blur();
-            }
-          }}
+          onChange={handleFileChange(handleFiles, resetOnChange)}
           multiple={multiple}
           disabled={disabled}
           accept={Array.isArray(accepts) ? accepts.join(',') : accepts}

--- a/src/components/FileUploadButton.tsx
+++ b/src/components/FileUploadButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { AttachmentIcon } from './AttachmentIcon';
-import { handleFileChange } from '../utils';
+import { useHandleFileChangeWrapper } from '../utils';
 
 export type FileUploadButtonProps = {
   handleFiles: (files: FileList | File[]) => void;
@@ -17,19 +17,22 @@ export const FileUploadButton: React.FC<FileUploadButtonProps> = ({
   children = <AttachmentIcon />,
   handleFiles,
   accepts,
-  resetOnChange = false,
+  resetOnChange = true,
 }) => {
   let className = 'rfu-file-upload-button';
   if (disabled) {
     className = `${className} rfu-file-upload-button--disabled`;
   }
+
+  const onFileChange = useHandleFileChangeWrapper(resetOnChange, handleFiles);
+
   return (
     <div className={className}>
       <label>
         <input
           type="file"
           className="rfu-file-input"
-          onChange={handleFileChange(handleFiles, resetOnChange)}
+          onChange={onFileChange}
           multiple={multiple}
           disabled={disabled}
           accept={Array.isArray(accepts) ? accepts.join(',') : accepts}

--- a/src/components/ImageUploadButton.tsx
+++ b/src/components/ImageUploadButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { PictureIcon } from './PictureIcon';
-import { handleFileChange } from '../utils';
+import { useHandleFileChangeWrapper } from '../utils';
 
 export type ImageUploadButtonProps = {
   handleFiles: (files: File[]) => void;
@@ -19,13 +19,15 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = (props) => {
     resetOnChange = false,
   } = props;
 
+  const onFileChange = useHandleFileChangeWrapper(resetOnChange, handleFiles);
+
   return (
     <div className="rfu-image-upload-button">
       <label>
         <input
           type="file"
           className="rfu-image-input"
-          onChange={handleFileChange(handleFiles, resetOnChange)}
+          onChange={onFileChange}
           accept="image/*"
           multiple={multiple}
           disabled={disabled}

--- a/src/components/ImageUploadButton.tsx
+++ b/src/components/ImageUploadButton.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
 import { PictureIcon } from './PictureIcon';
+import { handleFileChange } from '../utils';
 
 export type ImageUploadButtonProps = {
   handleFiles: (files: File[]) => void;
   multiple?: boolean;
   disabled?: boolean;
+  resetOnChange?: boolean;
 };
 
 export const ImageUploadButton: React.FC<ImageUploadButtonProps> = (props) => {
@@ -14,6 +16,7 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = (props) => {
     disabled = false,
     handleFiles,
     children = <PictureIcon />,
+    resetOnChange = false,
   } = props;
 
   return (
@@ -22,12 +25,7 @@ export const ImageUploadButton: React.FC<ImageUploadButtonProps> = (props) => {
         <input
           type="file"
           className="rfu-image-input"
-          onChange={(event) => {
-            const files = event.currentTarget.files;
-            if (files) {
-              handleFiles(Array.from(files));
-            }
-          }}
+          onChange={handleFileChange(handleFiles, resetOnChange)}
           accept="image/*"
           multiple={multiple}
           disabled={disabled}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,3 +92,20 @@ export async function dataTransferItemsToFiles(
   await Promise.all(blobPromises);
   return fileLikes;
 }
+
+export const handleFileChange = (
+  callback?: (files: Array<File>) => void,
+  resetOnChange: boolean = false,
+) => ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
+  const files = currentTarget.files;
+
+  if (!files) return;
+
+  try {
+    callback?.(Array.from(files));
+  } catch (error) {
+    console.error(error);
+  }
+
+  if (resetOnChange) currentTarget.value = '';
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import type { FileLike } from './types';
-import { useCallback } from 'react';
 
 // https://stackoverflow.com/a/6860916/2570866
 export function generateRandomId() {
@@ -96,21 +95,17 @@ export async function dataTransferItemsToFiles(
 
 export const useHandleFileChangeWrapper = (
   resetOnChange: boolean = false,
-  callback?: (files: Array<File>) => void,
-) =>
-  useCallback(
-    ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
-      const { files } = currentTarget;
+  handler?: (files: Array<File>) => void,
+) => ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
+  const { files } = currentTarget;
 
-      if (!files) return;
+  if (!files) return;
 
-      try {
-        callback?.(Array.from(files));
-      } catch (error) {
-        console.error(error);
-      }
+  try {
+    handler?.(Array.from(files));
+  } catch (error) {
+    console.error(error);
+  }
 
-      if (resetOnChange) currentTarget.value = '';
-    },
-    [callback, resetOnChange],
-  );
+  if (resetOnChange) currentTarget.value = '';
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { FileLike } from './types';
+import { useCallback } from 'react';
 
 // https://stackoverflow.com/a/6860916/2570866
 export function generateRandomId() {
@@ -93,19 +94,23 @@ export async function dataTransferItemsToFiles(
   return fileLikes;
 }
 
-export const handleFileChange = (
-  callback?: (files: Array<File>) => void,
+export const useHandleFileChangeWrapper = (
   resetOnChange: boolean = false,
-) => ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
-  const files = currentTarget.files;
+  callback?: (files: Array<File>) => void,
+) =>
+  useCallback(
+    ({ currentTarget }: React.ChangeEvent<HTMLInputElement>) => {
+      const { files } = currentTarget;
 
-  if (!files) return;
+      if (!files) return;
 
-  try {
-    callback?.(Array.from(files));
-  } catch (error) {
-    console.error(error);
-  }
+      try {
+        callback?.(Array.from(files));
+      } catch (error) {
+        console.error(error);
+      }
 
-  if (resetOnChange) currentTarget.value = '';
-};
+      if (resetOnChange) currentTarget.value = '';
+    },
+    [callback, resetOnChange],
+  );


### PR DESCRIPTION
Added `resetOnChange` property to both upload buttons so when user deletes file from preview and then decides to upload that same file again, they can. This thing has been already (partially) implemented in `FileUploadButton` with reference to `input` element so I decided to rewrite it a bit and add it to `ImageUploadButton` as well.

Here's the preview of the "bug":

https://user-images.githubusercontent.com/43254280/113438466-e8102500-93e8-11eb-97b8-a098e941b68d.mov