### PR TITLE
refactor: general component refactor (icons and types)

### DIFF
--- a/src/components/CloseIcon.tsx
+++ b/src/components/CloseIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const CloseIcon = () => (
+  <svg
+    width="28"
+    height="28"
+    viewBox="0 0 28 28"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlnsXlink="http://www.w3.org/1999/xlink"
+  >
+    <defs>
+      <path
+        d="M465 5c5.53 0 10 4.47 10 10s-4.47 10-10 10-10-4.47-10-10 4.47-10 10-10zm3.59 5L465 13.59 461.41 10 460 11.41l3.59 3.59-3.59 3.59 1.41 1.41 3.59-3.59 3.59 3.59 1.41-1.41-3.59-3.59 3.59-3.59-1.41-1.41z"
+        id="b"
+      />
+      <filter
+        x="-30%"
+        y="-30%"
+        width="160%"
+        height="160%"
+        filterUnits="objectBoundingBox"
+        id="a"
+      >
+        <feOffset in="SourceAlpha" result="shadowOffsetOuter1" />
+        <feGaussianBlur
+          stdDeviation="2"
+          in="shadowOffsetOuter1"
+          result="shadowBlurOuter1"
+        />
+        <feColorMatrix
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0"
+          in="shadowBlurOuter1"
+        />
+      </filter>
+    </defs>
+    <g transform="translate(-451 -1)" fillRule="nonzero" fill="none">
+      <use fill="#000" filter="url(#a)" xlinkHref="#b" />
+      <use fill="#FFF" fillRule="evenodd" xlinkHref="#b" />
+    </g>
+  </svg>
+);

--- a/src/components/FilePreviewer.tsx
+++ b/src/components/FilePreviewer.tsx
@@ -22,55 +22,52 @@ export const FilePreviewer = ({
 }: FilePreviewerProps) => (
   <div className="rfu-file-previewer">
     <ol>
-      {uploads &&
-        uploads.map((upload) => (
-          <li
-            key={upload.id}
-            className={`rfu-file-previewer__file ${
-              upload.state === 'uploading'
-                ? 'rfu-file-previewer__file--uploading'
-                : ''
-            } ${
-              upload.state === 'failed'
-                ? 'rfu-file-previewer__file--failed'
-                : ''
-            }`}
-          >
-            <FileIcon mimeType={upload.file.type} filename={upload.file.name} />
+      {uploads?.map((upload) => (
+        <li
+          key={upload.id}
+          className={`rfu-file-previewer__file ${
+            upload.state === 'uploading'
+              ? 'rfu-file-previewer__file--uploading'
+              : ''
+          } ${
+            upload.state === 'failed' ? 'rfu-file-previewer__file--failed' : ''
+          }`}
+        >
+          <FileIcon mimeType={upload.file.type} filename={upload.file.name} />
 
-            <a href={upload.url} download>
-              {upload.file.name}
-              {upload.state === 'failed' && (
-                <React.Fragment>
-                  <div
-                    className="rfu-file-previewer__failed"
-                    onClick={handleRetry && (() => handleRetry(upload.id))}
-                  >
-                    failed
-                  </div>
-                  <div
-                    className="rfu-file-previewer__retry"
-                    onClick={handleRetry && (() => handleRetry(upload.id))}
-                  >
-                    retry
-                  </div>
-                </React.Fragment>
-              )}
-            </a>
-
-            <span
-              className="rfu-file-previewer__close-button"
-              onClick={handleRemove && (() => handleRemove(upload.id))}
-            >
-              ✘
-            </span>
-            {upload.state === 'uploading' && (
-              <div className="rfu-file-previewer__loading-indicator">
-                <LoadingIndicator />
-              </div>
+          <a href={upload.url} download>
+            {upload.file.name}
+            {upload.state === 'failed' && (
+              <>
+                <div
+                  className="rfu-file-previewer__failed"
+                  onClick={() => handleRetry?.(upload.id)}
+                >
+                  failed
+                </div>
+                <div
+                  className="rfu-file-previewer__retry"
+                  onClick={() => handleRetry?.(upload.id)}
+                >
+                  retry
+                </div>
+              </>
             )}
-          </li>
-        ))}
+          </a>
+
+          <span
+            className="rfu-file-previewer__close-button"
+            onClick={handleRemove && (() => handleRemove(upload.id))}
+          >
+            ✘
+          </span>
+          {upload.state === 'uploading' && (
+            <div className="rfu-file-previewer__loading-indicator">
+              <LoadingIndicator />
+            </div>
+          )}
+        </li>
+      ))}
     </ol>
   </div>
 );

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,7 +1,7 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, MouseEventHandler } from 'react';
 
 export type IconButtonProps = {
-  onClick?: (e: React.SyntheticEvent) => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 };
 
 /**

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -5,13 +5,15 @@ export type IconButtonProps = {
 };
 
 /**
- * This is simply a button wrapper, add's a div with `role="button"` and a onClick
+ * This is simply a button wrapper, adds a div with `role="button"` and a onClick
  */
 export const IconButton = ({
   onClick,
   children,
 }: PropsWithChildren<IconButtonProps>) => (
   <button
+    type="button"
+    data-testid="cancel-upload-button"
     aria-label="Cancel upload"
     className="rfu-icon-button"
     onClick={onClick}

--- a/src/components/ImagePreviewer.tsx
+++ b/src/components/ImagePreviewer.tsx
@@ -1,18 +1,24 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, MouseEvent } from 'react';
 
 import { LoadingIndicator } from './LoadingIndicator';
 import { Thumbnail } from './Thumbnail';
 import { ThumbnailPlaceholder } from './ThumbnailPlaceholder';
+import { RetryIcon } from './RetryIcon';
 
 import type { ImageUpload } from '../types';
+
+type CustomMouseEvent = (
+  id: string,
+  event: MouseEvent<HTMLButtonElement>,
+) => void;
 
 export type ImagePreviewerProps = {
   /** The list of image uploads that should be displayed */
   imageUploads?: ImageUpload[];
   /** A callback to call when the remove icon is clicked */
-  handleRemove?: (id: string) => void;
+  handleRemove?: CustomMouseEvent;
   /** A callback to call when the retry icon is clicked */
-  handleRetry?: (id: string) => void;
+  handleRetry?: CustomMouseEvent;
   /** A callback to call with newly selected files. If this is not provided no
    * `ThumbnailPlaceholder` will be displayed.
    */
@@ -30,17 +36,13 @@ export const ImagePreviewer = ({
   handleRetry,
   handleFiles,
 }: ImagePreviewerProps) => {
-  const onClose = useCallback(
-    (id?: string) => {
-      if (handleRemove) {
-        if (id == null) {
-          console.warn(
-            "id of closed image was undefined, this shouldn't happen",
-          );
-          return;
-        }
-        handleRemove(id);
-      }
+  const onClose: CustomMouseEvent = useCallback(
+    (id, event) => {
+      if (!id)
+        return console.warn(
+          `image.id of closed image was "null", this shouldn't happen`,
+        );
+      handleRemove?.(id, event);
     },
     [handleRemove],
   );
@@ -62,22 +64,20 @@ export const ImagePreviewer = ({
               <button
                 aria-label="Retry upload"
                 className="rfu-image-previewer__retry"
-                dangerouslySetInnerHTML={{
-                  __html:
-                    '<svg width="22" height="20" viewBox="0 0 22 20" xmlns="http://www.w3.org/2000/svg"><path d="M20 5.535V2a1 1 0 0 1 2 0v6a1 1 0 0 1-1 1h-6a1 1 0 0 1 0-2h3.638l-2.975-2.653a8 8 0 1 0 1.884 8.32 1 1 0 1 1 1.886.666A10 10 0 1 1 5.175 1.245c3.901-2.15 8.754-1.462 11.88 1.667L20 5.535z" fill="#FFF" fill-rule="nonzero"/></svg>',
-                }}
-                onClick={handleRetry && (() => handleRetry(image.id))}
-              />
+                onClick={(event) => handleRetry?.(image.id, event)}
+              >
+                <RetryIcon />
+              </button>
             )}
 
-            {url !== undefined && (
-              <Thumbnail handleClose={onClose} image={url} id={image.id} />
+            {url && (
+              <Thumbnail
+                handleClose={(event) => onClose(image.id, event)}
+                image={url}
+              />
             )}
             {image.state === 'uploading' && (
-              <LoadingIndicator
-                backgroundColor="rgba(255,255,255,0.1)"
-                color="rgba(255,255,255,0.7)"
-              />
+              <LoadingIndicator backgroundColor="#ffffff19" color="#ffffffb2" />
             )}
           </div>
         );

--- a/src/components/ImagePreviewer.tsx
+++ b/src/components/ImagePreviewer.tsx
@@ -62,6 +62,7 @@ export const ImagePreviewer = ({
           >
             {image.state === 'failed' && (
               <button
+                type="button"
                 aria-label="Retry upload"
                 className="rfu-image-previewer__retry"
                 onClick={(event) => handleRetry?.(image.id, event)}

--- a/src/components/RetryIcon.tsx
+++ b/src/components/RetryIcon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export const RetryIcon = () => (
+  <svg
+    width="22"
+    height="20"
+    viewBox="0 0 22 20"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M20 5.535V2a1 1 0 0 1 2 0v6a1 1 0 0 1-1 1h-6a1 1 0 0 1 0-2h3.638l-2.975-2.653a8 8 0 1 0 1.884 8.32 1 1 0 1 1 1.886.666A10 10 0 1 1 5.175 1.245c3.901-2.15 8.754-1.462 11.88 1.667L20 5.535z"
+      fill="#FFF"
+      fillRule="nonzero"
+    />
+  </svg>
+);

--- a/src/components/Thumbnail.tsx
+++ b/src/components/Thumbnail.tsx
@@ -1,27 +1,27 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, MouseEventHandler } from 'react';
 
 import { IconButton } from './IconButton';
 import { FilePlaceholder } from './FilePlaceholder';
+import { CloseIcon } from './CloseIcon';
 
 export type ThumbnailProps = {
-  handleClose?: (id?: string) => void;
+  handleClose?: MouseEventHandler<HTMLButtonElement>;
   size?: number;
   image: string;
   alt?: string;
   id?: string;
 };
 
-const svg =
-  '<svg width="28" height="28" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><path d="M465 5c5.53 0 10 4.47 10 10s-4.47 10-10 10-10-4.47-10-10 4.47-10 10-10zm3.59 5L465 13.59 461.41 10 460 11.41l3.59 3.59-3.59 3.59 1.41 1.41 3.59-3.59 3.59 3.59 1.41-1.41-3.59-3.59 3.59-3.59-1.41-1.41z" id="b"/><filter x="-30%" y="-30%" width="160%" height="160%" filterUnits="objectBoundingBox" id="a"><feOffset in="SourceAlpha" result="shadowOffsetOuter1"/><feGaussianBlur stdDeviation="2" in="shadowOffsetOuter1" result="shadowBlurOuter1"/><feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.5 0" in="shadowBlurOuter1"/></filter></defs><g transform="translate(-451 -1)" fill-rule="nonzero" fill="none"><use fill="#000" filter="url(#a)" xlink:href="#b"/><use fill="#FFF" fill-rule="evenodd" xlink:href="#b"/></g></svg>';
-
 export const Thumbnail = ({
-  id,
   image,
   size = 100,
   handleClose,
   alt,
 }: ThumbnailProps) => {
-  const onClose = useCallback(() => handleClose?.(id), [id, handleClose]);
+  const onClose: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => handleClose?.(event),
+    [handleClose],
+  );
 
   return (
     <div
@@ -31,7 +31,7 @@ export const Thumbnail = ({
       <div className="rfu-thumbnail__overlay">
         {handleClose ? (
           <IconButton onClick={onClose}>
-            <div dangerouslySetInnerHTML={{ __html: svg }} />
+            <CloseIcon />
           </IconButton>
         ) : null}
       </div>


### PR DESCRIPTION
### 🎯 Goal

While writing E2E tests for the `stream-chat-react` I did some refactoring as a part of the investigation.

### 🛠 Implementation details

- moved SVG icons to separate components (`CloseIcon` and `RetryIcon`)
- clarified event types (`React.SyntheticEvent` to `MouseEvent<HTMLButtonElement>`)
- added second parameter (event) to the `handleRemove` and `handleRetry`
